### PR TITLE
Fix Boost audio downloads using direct MPD lookup

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/http/reddit/RedditFixAudioInDownloadsInterceptor.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/http/reddit/RedditFixAudioInDownloadsInterceptor.java
@@ -21,6 +21,7 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -65,20 +66,9 @@ public class RedditFixAudioInDownloadsInterceptor implements Interceptor {
             String baseUrl = matcher.group(1);
 
             /*
-             * Old implementation tried:
-             *
-             *   GET https://v.redd.it/<id>
-             *   follow redirect
-             *   GET <redirected reddit post>/.json
-             *   parse media.reddit_video.dash_url
-             *
-             * That is brittle. If Reddit returns HTML/XML/error/redirect instead of JSON,
-             * audio retrieval fails with:
-             *
-             *   JsonParseException: Unexpected character '<'
-             *
-             * For v.redd.it we already know the media base URL, so go directly to the
-             * DASH/MPD manifest.
+             * The intercepted request already contains the v.redd.it media base URL,
+             * so use the DASH manifest directly instead of resolving the Reddit post
+             * JSON through the v.redd.it redirect path.
              */
             String dashUrl = baseUrl + "/DASHPlaylist.mpd";
 
@@ -93,8 +83,9 @@ public class RedditFixAudioInDownloadsInterceptor implements Interceptor {
                 }
             }
 
-
             return HttpUtils.get(baseUrl + "/" + audioFilename);
+        } catch (NoAudioTrackException e) {
+            return chain.proceed(request);
         } catch (Exception e) {
             LoggingUtils.logException(false, () -> "Failed to retrieve audio: " + e);
             return chain.proceed(request);
@@ -115,6 +106,8 @@ public class RedditFixAudioInDownloadsInterceptor implements Interceptor {
         */
 
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        dbFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
         DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
         Document doc = dBuilder.parse(xmlDocumentStream);
         doc.getDocumentElement().normalize();
@@ -151,7 +144,7 @@ public class RedditFixAudioInDownloadsInterceptor implements Interceptor {
             return baseUrl;
         }
 
-        throw new RuntimeException("Unable to find matching audio track");
+        throw new NoAudioTrackException();
     }
 
     private boolean looksLikeAudioRepresentation(Element representation) {
@@ -178,5 +171,8 @@ public class RedditFixAudioInDownloadsInterceptor implements Interceptor {
     private boolean attributeStartsWith(Element element, String attributeName, String prefix) {
         String value = element.getAttribute(attributeName);
         return value != null && value.toLowerCase(Locale.ROOT).startsWith(prefix);
+    }
+
+    private static class NoAudioTrackException extends RuntimeException {
     }
 }

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/http/reddit/RedditFixAudioInDownloadsInterceptor.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/http/reddit/RedditFixAudioInDownloadsInterceptor.java
@@ -9,20 +9,18 @@ package app.morphe.extension.boostforreddit.http.reddit;
 
 import androidx.annotation.NonNull;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Strings;
-
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -57,6 +55,7 @@ public class RedditFixAudioInDownloadsInterceptor implements Interceptor {
         if (!enabled) {
             return chain.proceed(request);
         }
+
         Matcher matcher = VIDEO_REGEX.matcher(url);
         if (!matcher.find()) {
             return chain.proceed(request);
@@ -64,18 +63,36 @@ public class RedditFixAudioInDownloadsInterceptor implements Interceptor {
 
         try {
             String baseUrl = matcher.group(1);
-            JsonNode submissionData;
-            try (Response originalSubmission = HttpUtils.get(baseUrl)) {
-                try (Response submissionApiResponse = HttpUtils.get(originalSubmission.request().url() + "/.json")) {
-                    submissionData = HttpUtils.getJsonFromString(submissionApiResponse.body().string());
+
+            /*
+             * Old implementation tried:
+             *
+             *   GET https://v.redd.it/<id>
+             *   follow redirect
+             *   GET <redirected reddit post>/.json
+             *   parse media.reddit_video.dash_url
+             *
+             * That is brittle. If Reddit returns HTML/XML/error/redirect instead of JSON,
+             * audio retrieval fails with:
+             *
+             *   JsonParseException: Unexpected character '<'
+             *
+             * For v.redd.it we already know the media base URL, so go directly to the
+             * DASH/MPD manifest.
+             */
+            String dashUrl = baseUrl + "/DASHPlaylist.mpd";
+
+            String audioFilename;
+            try (Response dashPlaylistResponse = HttpUtils.get(dashUrl)) {
+                if (dashPlaylistResponse.body() == null) {
+                    throw new RuntimeException("DASH playlist response body was null");
+                }
+
+                try (InputStream dashPlaylistStream = dashPlaylistResponse.body().byteStream()) {
+                    audioFilename = parseDashPlaylist(dashPlaylistStream);
                 }
             }
 
-            String dashUrl = submissionData.get(0).get("data").get("children").get(0).get("data").get("media").get("reddit_video").get("dash_url").asText();
-
-            Response dashPlaylistResponse = HttpUtils.get(dashUrl);
-            InputStream dashPlaylistStream = dashPlaylistResponse.body().byteStream();
-            String audioFilename = parseDashPlaylist(dashPlaylistStream);
 
             return HttpUtils.get(baseUrl + "/" + audioFilename);
         } catch (Exception e) {
@@ -86,7 +103,7 @@ public class RedditFixAudioInDownloadsInterceptor implements Interceptor {
 
     private String parseDashPlaylist(InputStream xmlDocumentStream) throws IOException, SAXException, ParserConfigurationException {
         /*
-        Looking for something like this in the DASH playlist
+        Looking for something like this in the DASH playlist:
 
         <Representation audioSamplingRate="48000" bandwidth="131398" codecs="mp4a.40.2" id="7" mimeType="audio/mp4">
           <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
@@ -108,16 +125,58 @@ public class RedditFixAudioInDownloadsInterceptor implements Interceptor {
 
         for (int i = 0; i < representations.getLength(); i++) {
             Element representation = (Element) representations.item(i);
+
+            if (!looksLikeAudioRepresentation(representation)) {
+                continue;
+            }
+
             String bandwidthStr = representation.getAttribute("bandwidth");
-            if (bandwidthStr == null || bandwidthStr.isBlank()) continue;
+            if (bandwidthStr == null || bandwidthStr.isBlank()) {
+                continue;
+            }
+
+            NodeList baseUrls = representation.getElementsByTagName("BaseURL");
+            if (baseUrls == null || baseUrls.getLength() == 0 || baseUrls.item(0) == null) {
+                continue;
+            }
 
             int bandwidth = Integer.parseInt(bandwidthStr);
             if (bandwidth > maxBandwidth) {
-                baseUrl = representation.getElementsByTagName("BaseURL").item(0).getTextContent();
+                maxBandwidth = bandwidth;
+                baseUrl = baseUrls.item(0).getTextContent();
             }
         }
 
-        if (baseUrl != null) return baseUrl;
+        if (baseUrl != null && !baseUrl.isBlank()) {
+            return baseUrl;
+        }
+
         throw new RuntimeException("Unable to find matching audio track");
+    }
+
+    private boolean looksLikeAudioRepresentation(Element representation) {
+        if (attributeContains(representation, "mimeType", "audio")) return true;
+        if (attributeContains(representation, "contentType", "audio")) return true;
+        if (attributeStartsWith(representation, "codecs", "mp4a")) return true;
+
+        Node parent = representation.getParentNode();
+        if (parent instanceof Element) {
+            Element parentElement = (Element) parent;
+            if (attributeContains(parentElement, "mimeType", "audio")) return true;
+            if (attributeContains(parentElement, "contentType", "audio")) return true;
+            if (attributeStartsWith(parentElement, "codecs", "mp4a")) return true;
+        }
+
+        return false;
+    }
+
+    private boolean attributeContains(Element element, String attributeName, String needle) {
+        String value = element.getAttribute(attributeName);
+        return value != null && value.toLowerCase(Locale.ROOT).contains(needle);
+    }
+
+    private boolean attributeStartsWith(Element element, String attributeName, String prefix) {
+        String value = element.getAttribute(attributeName);
+        return value != null && value.toLowerCase(Locale.ROOT).startsWith(prefix);
     }
 }

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/http/reddit/RedditFixAudioInDownloadsInterceptor.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/http/reddit/RedditFixAudioInDownloadsInterceptor.java
@@ -21,7 +21,6 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -106,8 +105,6 @@ public class RedditFixAudioInDownloadsInterceptor implements Interceptor {
         */
 
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-        dbFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-
         DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
         Document doc = dBuilder.parse(xmlDocumentStream);
         doc.getDocumentElement().normalize();


### PR DESCRIPTION
This fixes Boost for Reddit audio retrieval for v.redd.it video downloads/shares.

The previous implementation tried to resolve the Reddit post JSON by requesting the v.redd.it base URL, following the redirected URL, and then appending /.json. Reddit currently returns a non-JSON response in this path for some videos, causing:

Failed to retrieve audio:
com.fasterxml.jackson.core.JsonParseException:
Unexpected character ('<' (code 60))

Since the intercepted request already contains the v.redd.it media base URL, this change avoids the brittle Reddit JSON lookup and fetches the DASH manifest directly from:

https://v.redd.it/<id>/DASHPlaylist.mpd

The existing MPD parser is then used to resolve the audio BaseURL.

This also fixes the parser’s bandwidth selection logic by updating maxBandwidth when a better audio representation is found, and filters the selection so it only considers audio representations.

Tested locally with Boost 1.12.12 patched through Morphe using a local Patcheddit .mpp bundle.

Before:

* Boost playback had audio.
* Sharing/downloading showed Failed to retrieve audio.
* Logcat showed JsonParseException: Unexpected character '<'.

After:

* Sharing/downloading works with audio.
* No Failed to retrieve audio toast.
