### PR TITLE
Fix slow Giphy loading in Boost

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/giphy/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/giphy/Fingerprints.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2026 wchill.
+ * https://github.com/wchill/patcheddit
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+
+package app.morphe.patches.reddit.customclients.boostforreddit.fix.giphy
+
+import app.morphe.patcher.Fingerprint
+
+internal val resolveGiphyApiFingerprint = Fingerprint(
+    strings = listOf("dc6zaTOxFJmzC"),
+    custom = { _, classDef -> classDef.sourceFile == "GifUrlExtractorCancelable.java" }
+)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/giphy/FixSlowGiphyLoadingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/giphy/FixSlowGiphyLoadingPatch.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 wchill.
+ * https://github.com/wchill/patcheddit
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+
+package app.morphe.patches.reddit.customclients.boostforreddit.fix.giphy
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.reddit.customclients.boostforreddit.BoostCompatible
+
+@Suppress("unused")
+val fixSlowGiphyLoadingPatch = bytecodePatch(
+    name = "Fix slow Giphy loading",
+    description = "Bypasses Boost's slow Giphy API resolver and uses Boost's direct media.giphy.com MP4 fallback for Giphy posts.",
+    default = true
+) {
+    compatibleWith(*BoostCompatible)
+
+    execute {
+        resolveGiphyApiFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-direct { p0 }, Lhe/r;->x()V
+                return-void
+                """
+        )
+    }
+}


### PR DESCRIPTION
Fixes slow Giphy loading in Boost for Reddit.

Boost currently resolves Giphy posts through its old Giphy API resolver:

api.giphy.com/v1/gifs/{gif_id}

That adds a large delay before playback starts. In testing, the same Giphy item loaded through Boost after roughly 8 seconds, while the direct Giphy MP4 URL loaded essentially instantly.

Boost already has an internal fallback method that constructs the direct MP4 URL:

https://media.giphy.com/media/<id>/giphy.mp4

This patch bypasses the slow Giphy API resolver and calls Boost's existing direct MP4 fallback instead.

Tested with:
- Boost 1.12.12
- Morphe Manager
- Local Patcheddit .mpp bundle
- Example Giphy item: 1201hONkUdpK36

Before:
- Giphy media took several seconds to start.

After:
- Giphy media starts essentially immediately.

The patch is intentionally small:
- It fingerprints Boost's `GifUrlExtractorCancelable.java` Giphy API resolver using the old public Giphy API key string.
- It replaces the resolver path by calling Boost's existing `x()` fallback method.
- It does not add a new HTTP interceptor or new media handling logic.
