### PR TITLE
fix RedGifs API for rif is fun

### DIFF
--- a/extensions/redditisfun/src/main/java/app/morphe/extension/redditisfun/FixRedgifsApiPatch.java
+++ b/extensions/redditisfun/src/main/java/app/morphe/extension/redditisfun/FixRedgifsApiPatch.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 wchill.
+ * https://github.com/wchill/patcheddit
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+
+package app.morphe.extension.redditisfun;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.fixes.redgifs.RedgifsTokenManager;
+
+/**
+ * @noinspection unused
+ */
+public class FixRedgifsApiPatch {
+    // RIF's hardcoded RedGifs user agent; RedGifs binds the temporary token to it.
+    private static final String USER_AGENT = "org.quantumbadger.redreader/1.25.1";
+
+    public static String getRedgifsToken() {
+        try {
+            return RedgifsTokenManager.refreshToken(USER_AGENT).getAccessToken();
+        } catch (Exception ex) {
+            Logger.printException(() -> "Could not fetch RedGifs token", ex);
+            return null;
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/redditisfun/fix/redgifs/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/redditisfun/fix/redgifs/Fingerprints.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 wchill.
+ * https://github.com/wchill/patcheddit
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+
+package app.morphe.patches.reddit.customclients.redditisfun.fix.redgifs
+
+import app.morphe.patcher.Fingerprint
+
+// Method that requests a RedGifs token from the removed /v2/oauth/client endpoint.
+internal object RedgifsTokenFingerprint : Fingerprint(
+    returnType = "Ljava/lang/String;",
+    strings = listOf("https://api.redgifs.com/v2/oauth/client"),
+)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/redditisfun/fix/redgifs/FixRedgifsApiPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/redditisfun/fix/redgifs/FixRedgifsApiPatch.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 wchill.
+ * https://github.com/wchill/patcheddit
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+
+package app.morphe.patches.reddit.customclients.redditisfun.fix.redgifs
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.reddit.customclients.AppCompatibility
+import app.morphe.patches.reddit.customclients.ExtensionPatches
+
+private const val EXTENSION_CLASS_DESCRIPTOR =
+    "Lapp/morphe/extension/redditisfun/FixRedgifsApiPatch;"
+
+val fixRedgifsApiPatch = bytecodePatch(
+    name = "Fix Redgifs API",
+    description = "Fix RedGifs videos and gifs not loading.",
+    default = true,
+) {
+    dependsOn(ExtensionPatches.RIF)
+    compatibleWith(*AppCompatibility.RedditIsFun)
+
+    execute {
+        // RIF requests a token from the removed /v2/oauth/client endpoint. Return a valid
+        // RedGifs temporary token from the extension instead.
+        RedgifsTokenFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-static { }, $EXTENSION_CLASS_DESCRIPTOR->getRedgifsToken()Ljava/lang/String;
+                move-result-object v0
+                return-object v0
+            """,
+        )
+    }
+}


### PR DESCRIPTION
**Disclaimer: bot generated.** I didn't open an issue because I had the fix already on my end. Take it or leave it :)

***

Adds a **Fix Redgifs API** patch for *rif is fun* (`com.andrewshu.android.reddit` / `redditdonation`), which currently has no RedGifs support in patcheddit.

### Problem
RIF authenticates to RedGifs by requesting `https://api.redgifs.com/v2/oauth/client`, which RedGifs removed. RIF never obtains a token, so all RedGifs media fails to load.

### Approach
Unlike Boost/BaconReader/Sync, RIF ships a fully R8-minified OkHttp (`OkHttpClient` is `okhttp3.a0`, etc.), so the shared `BaseOkHttpRequestHook`/interceptor path can't be linked against it. Instead, this hooks RIF's token-fetch method (located via the dead `/v2/oauth/client` string) and returns a valid RedGifs temporary token from the existing shared `RedgifsTokenManager`, which uses `HttpURLConnection` and has no OkHttp dependency. RIF's own `Authorization: Bearer` logic then works unchanged.

The RedGifs user agent is RIF's hardcoded default (`org.quantumbadger.redreader/1.25.1`), which RedGifs binds the token to.

### Testing
- Verified end-to-end on the `v1.4.0` release base: built the bundle, patched a clean RIF 5.6.22 with the full patch set, confirmed the injected bytecode returns the extension token and the dead `/v2/oauth/client` path is bypassed, and confirmed RedGifs plays on-device.
- Verified the RedGifs token flow live: temporary token → `Bearer` → `/v2/gifs/<id>` → `200` + media URLs.
- Ported to `dev`'s current conventions (`AppCompatibility.RedditIsFun`, `ExtensionPatches.RIF`, `object … : Fingerprint`); the `redditisfun` extension module compiles against `dev`. I couldn't run a full `dev` build locally because `dev`'s `ExtensionPatches.kt` requires a newer `app.morphe.patches` plugin than the published `1.3.2` (unrelated to this change) — the CI build will be authoritative.
