### PR TITLE
fix: Emulate removed Redgifs /info endpoint

### DIFF
--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/fixes/redgifs/BaseFixRedgifsApiPatch.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/fixes/redgifs/BaseFixRedgifsApiPatch.java
@@ -38,6 +38,7 @@ public abstract class BaseFixRedgifsApiPatch extends PatchedditInterceptor {
         Logger.printInfo(() -> "Redgifs: intercepted " + request.method() + " " + path);
 
         String userAgent = getDefaultUserAgent();
+        boolean forceTokenRefresh = false;
 
         if (request.header("Authorization") != null) {
             Response response;
@@ -54,15 +55,18 @@ public abstract class BaseFixRedgifsApiPatch extends PatchedditInterceptor {
             }
             Logger.printInfo(() -> "Redgifs: request failed (existing Authorization) for " + path
                     + ", code=" + response.code() + "; refreshing token");
-            // The cached token (if any) is presumably the one that was just rejected, since it's
-            // what the app used to build its own Authorization header. isValid() only checks
-            // time-based expiry, so without invalidating it here, the refreshToken() call below
-            // would just hand back the same already-rejected token instead of minting a new one.
-            RedgifsTokenManager.invalidateToken(userAgent);
             // It's possible that the user agent is being overwritten later down in the interceptor
             // chain, so make sure we grab the new user agent from the request headers.
-            userAgent = response.request().header("User-Agent");
+            String responseUserAgent = response.request().header("User-Agent");
+            if (responseUserAgent != null && !responseUserAgent.isEmpty()) {
+                userAgent = responseUserAgent;
+            }
             response.close();
+
+            // Redgifs tokens are tied to the IP address that requested them. A cached token can
+            // therefore become invalid before its normal expiry when the device changes networks.
+            // Do not retry the failed request with the same cached token.
+            forceTokenRefresh = true;
         }
         final String finalUserAgent = userAgent;
 
@@ -77,7 +81,7 @@ public abstract class BaseFixRedgifsApiPatch extends PatchedditInterceptor {
 
             RedgifsTokenManager.RedgifsToken token;
             try {
-                token = RedgifsTokenManager.refreshToken(userAgent);
+                token = RedgifsTokenManager.refreshToken(userAgent, forceTokenRefresh);
             } catch (IOException ex) {
                 Logger.printException(() -> "Redgifs: failed to obtain temporary token for user agent \""
                         + finalUserAgent + "\"", ex);

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/fixes/redgifs/BaseFixRedgifsApiPatch.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/fixes/redgifs/BaseFixRedgifsApiPatch.java
@@ -54,6 +54,11 @@ public abstract class BaseFixRedgifsApiPatch extends PatchedditInterceptor {
             }
             Logger.printInfo(() -> "Redgifs: request failed (existing Authorization) for " + path
                     + ", code=" + response.code() + "; refreshing token");
+            // The cached token (if any) is presumably the one that was just rejected, since it's
+            // what the app used to build its own Authorization header. isValid() only checks
+            // time-based expiry, so without invalidating it here, the refreshToken() call below
+            // would just hand back the same already-rejected token instead of minting a new one.
+            RedgifsTokenManager.invalidateToken(userAgent);
             // It's possible that the user agent is being overwritten later down in the interceptor
             // chain, so make sure we grab the new user agent from the request headers.
             userAgent = response.request().header("User-Agent");

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/fixes/redgifs/BaseFixRedgifsApiPatch.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/fixes/redgifs/BaseFixRedgifsApiPatch.java
@@ -48,20 +48,19 @@ public abstract class BaseFixRedgifsApiPatch extends PatchedditInterceptor {
         }
 
         try {
+            // Emulate response for the old client IP lookup endpoint, which Redgifs has removed.
+            // It was only ever used to populate the legacy "user-addr" query parameter, which
+            // current Redgifs endpoints accept but ignore, so the actual value doesn't matter.
+            if (request.url().encodedPath().equals("/info")) {
+                return buildLocalJsonResponse(request, RedgifsTokenManager.getEmulatedIpResponseBody());
+            }
+
             RedgifsTokenManager.RedgifsToken token = RedgifsTokenManager.refreshToken(userAgent);
 
             // Emulate response for old OAuth endpoint
             if (request.url().encodedPath().equals("/v2/oauth/client")) {
                 String responseBody = RedgifsTokenManager.getEmulatedOAuthResponseBody(token);
-                return new Response.Builder()
-                        .message("OK")
-                        .code(HttpURLConnection.HTTP_OK)
-                        .protocol(Protocol.HTTP_1_1)
-                        .request(request)
-                        .header("Content-Type", "application/json")
-                        .body(ResponseBody.create(
-                                responseBody, MediaType.get("application/json")))
-                        .build();
+                return buildLocalJsonResponse(request, responseBody);
             }
 
             Request modifiedRequest = request.newBuilder()
@@ -73,5 +72,16 @@ public abstract class BaseFixRedgifsApiPatch extends PatchedditInterceptor {
             Logger.printException(() -> "Could not parse Redgifs response", ex);
             throw new IOException(ex);
         }
+    }
+
+    private static Response buildLocalJsonResponse(Request request, String jsonBody) {
+        return new Response.Builder()
+                .message("OK")
+                .code(HttpURLConnection.HTTP_OK)
+                .protocol(Protocol.HTTP_1_1)
+                .request(request)
+                .header("Content-Type", "application/json")
+                .body(ResponseBody.create(jsonBody, MediaType.get("application/json")))
+                .build();
     }
 }

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/fixes/redgifs/BaseFixRedgifsApiPatch.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/fixes/redgifs/BaseFixRedgifsApiPatch.java
@@ -34,31 +34,54 @@ public abstract class BaseFixRedgifsApiPatch extends PatchedditInterceptor {
             return chain.proceed(request);
         }
 
+        final String path = request.url().encodedPath();
+        Logger.printInfo(() -> "Redgifs: intercepted " + request.method() + " " + path);
+
         String userAgent = getDefaultUserAgent();
 
         if (request.header("Authorization") != null) {
-            Response response = chain.proceed(request.newBuilder().header("User-Agent", userAgent).build());
+            Response response;
+            try {
+                response = chain.proceed(request.newBuilder().header("User-Agent", userAgent).build());
+            } catch (IOException ex) {
+                Logger.printException(() -> "Redgifs: request failed (existing Authorization) for " + path, ex);
+                throw ex;
+            }
             if (response.isSuccessful()) {
+                Logger.printInfo(() -> "Redgifs: request succeeded (existing Authorization) for " + path
+                        + ", code=" + response.code());
                 return response;
             }
+            Logger.printInfo(() -> "Redgifs: request failed (existing Authorization) for " + path
+                    + ", code=" + response.code() + "; refreshing token");
             // It's possible that the user agent is being overwritten later down in the interceptor
             // chain, so make sure we grab the new user agent from the request headers.
             userAgent = response.request().header("User-Agent");
             response.close();
         }
+        final String finalUserAgent = userAgent;
 
         try {
             // Emulate response for the old client IP lookup endpoint, which Redgifs has removed.
             // It was only ever used to populate the legacy "user-addr" query parameter, which
             // current Redgifs endpoints accept but ignore, so the actual value doesn't matter.
-            if (request.url().encodedPath().equals("/info")) {
+            if (path.equals("/info")) {
+                Logger.printInfo(() -> "Redgifs: emulating /info response locally");
                 return buildLocalJsonResponse(request, RedgifsTokenManager.getEmulatedIpResponseBody());
             }
 
-            RedgifsTokenManager.RedgifsToken token = RedgifsTokenManager.refreshToken(userAgent);
+            RedgifsTokenManager.RedgifsToken token;
+            try {
+                token = RedgifsTokenManager.refreshToken(userAgent);
+            } catch (IOException ex) {
+                Logger.printException(() -> "Redgifs: failed to obtain temporary token for user agent \""
+                        + finalUserAgent + "\"", ex);
+                throw ex;
+            }
 
             // Emulate response for old OAuth endpoint
-            if (request.url().encodedPath().equals("/v2/oauth/client")) {
+            if (path.equals("/v2/oauth/client")) {
+                Logger.printInfo(() -> "Redgifs: emulating /v2/oauth/client response locally");
                 String responseBody = RedgifsTokenManager.getEmulatedOAuthResponseBody(token);
                 return buildLocalJsonResponse(request, responseBody);
             }
@@ -67,7 +90,15 @@ public abstract class BaseFixRedgifsApiPatch extends PatchedditInterceptor {
                     .header("Authorization", "Bearer " + token.getAccessToken())
                     .header("User-Agent", userAgent)
                     .build();
-            return chain.proceed(modifiedRequest);
+            Response response;
+            try {
+                response = chain.proceed(modifiedRequest);
+            } catch (IOException ex) {
+                Logger.printException(() -> "Redgifs: request failed for " + path, ex);
+                throw ex;
+            }
+            Logger.printInfo(() -> "Redgifs: request for " + path + " returned code=" + response.code());
+            return response;
         } catch (JSONException ex) {
             Logger.printException(() -> "Could not parse Redgifs response", ex);
             throw new IOException(ex);

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/fixes/redgifs/RedgifsTokenManager.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/fixes/redgifs/RedgifsTokenManager.java
@@ -90,4 +90,12 @@ public class RedgifsTokenManager {
         responseObject.put("token_type", "Bearer");
         return responseObject.toString();
     }
+
+    public static String getEmulatedIpResponseBody() throws JSONException {
+        // The real endpoint is gone, and current Redgifs endpoints accept but ignore the
+        // "user-addr" value that's populated from this response, so any placeholder works.
+        JSONObject responseObject = new JSONObject();
+        responseObject.put("remote-addr", "0.0.0.0");
+        return responseObject.toString();
+    }
 }

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/fixes/redgifs/RedgifsTokenManager.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/fixes/redgifs/RedgifsTokenManager.java
@@ -63,17 +63,16 @@ public class RedgifsTokenManager {
         return responseObject.getString("token");
     }
 
-    public static void invalidateToken(String userAgent) {
-        synchronized(tokenMap) {
-            tokenMap.remove(userAgent);
-        }
+    public static RedgifsToken refreshToken(String userAgent) throws IOException, JSONException {
+        return refreshToken(userAgent, false);
     }
 
-    public static RedgifsToken refreshToken(String userAgent) throws IOException, JSONException {
+    public static RedgifsToken refreshToken(String userAgent, boolean forceRefresh)
+            throws IOException, JSONException {
         synchronized(tokenMap) {
             // Reference: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/pull/67
             RedgifsToken token = tokenMap.get(userAgent);
-            if (token != null && token.isValid()) {
+            if (!forceRefresh && token != null && token.isValid()) {
                 return token;
             }
 

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/fixes/redgifs/RedgifsTokenManager.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/fixes/redgifs/RedgifsTokenManager.java
@@ -63,6 +63,12 @@ public class RedgifsTokenManager {
         return responseObject.getString("token");
     }
 
+    public static void invalidateToken(String userAgent) {
+        synchronized(tokenMap) {
+            tokenMap.remove(userAgent);
+        }
+    }
+
     public static RedgifsToken refreshToken(String userAgent) throws IOException, JSONException {
         synchronized(tokenMap) {
             // Reference: https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/pull/67

--- a/extensions/syncforreddit/src/main/java/app/morphe/extension/syncforreddit/FixRedgifsApiPatch.java
+++ b/extensions/syncforreddit/src/main/java/app/morphe/extension/syncforreddit/FixRedgifsApiPatch.java
@@ -26,4 +26,36 @@ public class FixRedgifsApiPatch extends BaseFixRedgifsApiPatch {
     public static OkHttpClient install(OkHttpClient.Builder builder) {
         return builder.addInterceptor(INSTANCE).build();
     }
+
+    /**
+     * Replacement for Sync's LinkHandler.getGfycatId (y7.a.d), which feeds the
+     * Redgifs API URL builder. The original strips the trailing slash BEFORE the
+     * query/fragment, so a URL like "https://www.redgifs.com/watch/<id>/?92/"
+     * leaves "?92" as the last path segment and the query-strip then reduces the
+     * "ID" to an empty string -- the API call goes out as /v2/gifs/ and 404s.
+     * Strip query/fragment from the full URL first, then take the last segment.
+     * Suffix cleanup kept identical to the original for parity (same replaces,
+     * same order, same dash-split). Deliberately NO ".jpg" strip: type-2 image
+     * posts resolve to .jpg URLs that Sync feeds to its VIDEO player (error 14
+     * "Could not load video"); keeping the suffix lets the API 404 so the
+     * WebView fallback displays the image instead.
+     */
+    public static String extractGifId(String url) {
+        if (url == null) return null;
+        try {
+            int queryStart = url.indexOf('?');
+            if (queryStart >= 0) url = url.substring(0, queryStart);
+            int fragmentStart = url.indexOf('#');
+            if (fragmentStart >= 0) url = url.substring(0, fragmentStart);
+            if (url.endsWith("/")) url = url.substring(0, url.length() - 1);
+            String id = url.substring(url.lastIndexOf('/') + 1);
+            id = id.replace(".gif", "").replace(".mp4", "").replace(".webm", "")
+                    .replace("-mobile", "").replace("-size_restricted", "")
+                    .replace("-max-1mb-poster", "");
+            if (id.contains("-")) id = id.split("-")[0];
+            return id;
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
 }

--- a/extensions/syncforreddit/src/main/java/app/morphe/extension/syncforreddit/RedgifsWebViewHelper.java
+++ b/extensions/syncforreddit/src/main/java/app/morphe/extension/syncforreddit/RedgifsWebViewHelper.java
@@ -1,0 +1,56 @@
+package app.morphe.extension.syncforreddit;
+
+import android.net.Uri;
+import android.webkit.CookieManager;
+import android.webkit.WebView;
+
+/**
+ * Helpers for the "Open Redgifs links in WebView" patch: auto-accept the
+ * CookieYes consent banner on redgifs pages and keep the consent cookie
+ * alive across WebView opens.
+ */
+public class RedgifsWebViewHelper {
+
+    // CookieYes accept button: current markup ([data-cky-tag="accept-button"])
+    // with the legacy class (.cky-btn-accept) as fallback. The banner is built
+    // asynchronously after page-finished, so poll briefly instead of firing once.
+    private static final String ACCEPT_JS =
+            "(function(){var n=0,t=setInterval(function(){"
+            + "var b=document.querySelector('[data-cky-tag=\"accept-button\"]')"
+            + "||document.querySelector('.cky-btn-accept');"
+            + "if(b){b.click();clearInterval(t);}"
+            + "if(++n>20)clearInterval(t);},250);})();";
+
+    /**
+     * Called from WebViewFragment$a.onPageFinished: auto-click the CookieYes
+     * accept button on redgifs pages. Clicking sets CookieYes's own consent
+     * cookie, which then persists (see shouldKeepCookies), so the banner --
+     * and this click -- only ever happen once.
+     */
+    public static void onPageFinished(WebView view, String url) {
+        if (!isRedgifs(url)) return;
+        view.evaluateJavascript(ACCEPT_JS, null);
+    }
+
+    /**
+     * Sync's WebViewFragment wipes ALL cookies on every fresh WebView open
+     * (CookieManager.removeAllCookie() before loadUrl). Called in place of the
+     * wipe: skips it for redgifs URLs so the CookieYes consent cookie survives
+     * between opens, and performs it unchanged for everything else.
+     */
+    public static void removeAllCookieUnlessRedgifs(CookieManager cookieManager, String url) {
+        if (!shouldKeepCookies(url)) {
+            cookieManager.removeAllCookie();
+        }
+    }
+
+    public static boolean shouldKeepCookies(String url) {
+        return isRedgifs(url);
+    }
+
+    private static boolean isRedgifs(String url) {
+        if (url == null) return false;
+        String host = Uri.parse(url).getHost();
+        return host != null && (host.equals("redgifs.com") || host.endsWith(".redgifs.com"));
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/ExtensionPatches.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/ExtensionPatches.kt
@@ -7,7 +7,8 @@ import app.morphe.patches.all.misc.extension.sharedExtensionPatch
 object ExtensionPatches {
     private fun hook(extensionName: String, vararg hookedClasses: String): BytecodePatch =
         sharedExtensionPatch(
-            extensionName, *hookedClasses.map { activityOnCreateExtensionHook(it) }.toTypedArray()
+            listOf(extensionName),
+            *hookedClasses.map { activityOnCreateExtensionHook(it) }.toTypedArray(),
         )
     internal val BaconReader = hook("baconreader", "Lcom/onelouder/baconreader/BaconReader;")
 

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifs/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifs/Fingerprints.kt
@@ -43,3 +43,15 @@ internal object GetOriginalUserAgentFingerprint : Fingerprint(
     parameters = listOf(),
     custom = { _, classDef -> classDef.sourceFile == "AccountSingleton.java" }
 )
+
+// LinkHandler.getGfycatId (y7.a.d): extracts the gif ID from a gfycat/redgifs
+// URL. Its strip-order bug (trailing slash before query) turns IDs from URLs
+// like "redgifs.com/watch/<id>/?92/" into empty strings, and the API call then
+// 404s. Class name is not obfuscated in Sync v23.06.30; the single-char method
+// name is, but the exact signature match is unique within the class.
+internal object LinkHandlerGetGfycatIdFingerprint : Fingerprint(
+    definingClass = "Ly7/a;",
+    name = "d",
+    parameters = listOf("Ljava/lang/String;"),
+    returnType = "Ljava/lang/String;",
+)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifs/FixRedgifsApiPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifs/FixRedgifsApiPatch.kt
@@ -56,5 +56,24 @@ val fixRedgifsApi = fixRedgifsApiPatch(
         }
 
         // endregion
+
+        // region Fix malformed Redgifs URL ID extraction.
+
+        // LinkHandler.getGfycatId strips the trailing slash before the query,
+        // so URLs like "redgifs.com/watch/<id>/?92/" yield an empty ID and the
+        // API 404s. Redirect the whole method to the corrected extension
+        // implementation; the original body becomes dead code after the return.
+        LinkHandlerGetGfycatIdFingerprint.method.apply {
+            addInstructions(
+                0,
+                """
+                invoke-static { p0 }, $EXTENSION_CLASS_DESCRIPTOR->extractGifId(Ljava/lang/String;)Ljava/lang/String;
+                move-result-object p0
+                return-object p0
+                """
+            )
+        }
+
+        // endregion
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifswebview/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifswebview/Fingerprints.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 wchill.
+ * https://github.com/wchill/patcheddit
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+
+package app.morphe.patches.reddit.customclients.sync.syncforreddit.fix.redgifswebview
+
+import app.morphe.patcher.Fingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+// LinkHelper.M(): decides whether to open a Redgifs link in the native media viewer or
+// externally in a browser, based on the app's "open internally" setting.
+internal val openRedgifsLinkFingerprint = Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
+    returnType = "V",
+    parameters = listOf(
+        "Landroid/content/Context;",
+        "[Lr0/d;",
+        "Ljava/lang/String;",
+        "Ljava/lang/String;",
+        "Ljava/lang/String;",
+        "Ljava/lang/String;",
+        "Ljava/lang/String;",
+        "Z",
+        "Z",
+    ),
+    strings = listOf("Opening RedGifs link internally: "),
+)
+
+// SettingsSingleton.p(Context): builds a Settings instance by reading each known boolean
+// (and other) preference individually via SharedPreferences.getBoolean(key, default) --
+// NOT via Gson/reflection. A field added to Settings without a corresponding read here
+// never actually gets populated from SharedPreferences; it just stays at its Java default.
+internal val loadSettingsFingerprint = Fingerprint(
+    accessFlags = listOf(AccessFlags.PRIVATE),
+    returnType = "Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton\$Settings;",
+    parameters = listOf("Landroid/content/Context;"),
+    strings = listOf("doh"),
+)

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifswebview/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifswebview/Fingerprints.kt
@@ -10,23 +10,39 @@ package app.morphe.patches.reddit.customclients.sync.syncforreddit.fix.redgifswe
 import app.morphe.patcher.Fingerprint
 import com.android.tools.smali.dexlib2.AccessFlags
 
-// LinkHelper.M(): decides whether to open a Redgifs link in the native media viewer or
-// externally in a browser, based on the app's "open internally" setting.
-internal val openRedgifsLinkFingerprint = Fingerprint(
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
+// ImageViewerFragment$g0.onErrorResponse(VolleyError): the single failure funnel for
+// Sync's Redgifs playback flow. The OAuth token request, the /info request, and the
+// actual /v2/gifs/<id> request all deliver errors to this listener, which then shows
+// "Error connecting to Redgifs" (error code 40). Its `a` field holds the original
+// redgifs.com URL that was being loaded -- exactly what a WebView fallback needs.
+// Class names are not obfuscated in Sync v23.06.30 and the method is a Volley
+// interface override, so an exact class+name+signature match is stable.
+internal val redgifsErrorListenerFingerprint = Fingerprint(
+    definingClass = "Lcom/laurencedawson/reddit_sync/ui/fragments/ImageViewerFragment\$g0;",
+    name = "onErrorResponse",
+    parameters = listOf("Lcom/android/volley/VolleyError;"),
     returnType = "V",
-    parameters = listOf(
-        "Landroid/content/Context;",
-        "[Lr0/d;",
-        "Ljava/lang/String;",
-        "Ljava/lang/String;",
-        "Ljava/lang/String;",
-        "Ljava/lang/String;",
-        "Ljava/lang/String;",
-        "Z",
-        "Z",
-    ),
-    strings = listOf("Opening RedGifs link internally: "),
+)
+
+// WebViewFragment$a.onPageFinished(WebView, String): the in-app browser's
+// WebViewClient page-finished callback. Used to auto-accept the CookieYes
+// consent banner on redgifs pages.
+internal val webViewClientOnPageFinishedFingerprint = Fingerprint(
+    definingClass = "Lcom/laurencedawson/reddit_sync/ui/fragments/WebViewFragment\$a;",
+    name = "onPageFinished",
+    parameters = listOf("Landroid/webkit/WebView;", "Ljava/lang/String;"),
+    returnType = "V",
+)
+
+// WebViewFragment.o2(View, Bundle) = onViewCreated: sets up the WebView and, on
+// a fresh open, clears history/form/cache and wipes ALL cookies via
+// CookieManager.removeAllCookie() before loadUrl. Patched to skip the wipe for
+// redgifs URLs so the CookieYes consent cookie persists between opens.
+internal val webViewFragmentOnViewCreatedFingerprint = Fingerprint(
+    definingClass = "Lcom/laurencedawson/reddit_sync/ui/fragments/WebViewFragment;",
+    name = "o2",
+    parameters = listOf("Landroid/view/View;", "Landroid/os/Bundle;"),
+    returnType = "V",
 )
 
 // SettingsSingleton.p(Context): builds a Settings instance by reading each known boolean

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifswebview/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifswebview/Fingerprints.kt
@@ -8,7 +8,6 @@
 package app.morphe.patches.reddit.customclients.sync.syncforreddit.fix.redgifswebview
 
 import app.morphe.patcher.Fingerprint
-import com.android.tools.smali.dexlib2.AccessFlags
 
 // ImageViewerFragment$g0.onErrorResponse(VolleyError): the single failure funnel for
 // Sync's Redgifs playback flow. The OAuth token request, the /info request, and the
@@ -43,15 +42,4 @@ internal val webViewFragmentOnViewCreatedFingerprint = Fingerprint(
     name = "o2",
     parameters = listOf("Landroid/view/View;", "Landroid/os/Bundle;"),
     returnType = "V",
-)
-
-// SettingsSingleton.p(Context): builds a Settings instance by reading each known boolean
-// (and other) preference individually via SharedPreferences.getBoolean(key, default) --
-// NOT via Gson/reflection. A field added to Settings without a corresponding read here
-// never actually gets populated from SharedPreferences; it just stays at its Java default.
-internal val loadSettingsFingerprint = Fingerprint(
-    accessFlags = listOf(AccessFlags.PRIVATE),
-    returnType = "Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton\$Settings;",
-    parameters = listOf("Landroid/content/Context;"),
-    strings = listOf("doh"),
 )

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifswebview/OpenRedgifsInWebViewPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifswebview/OpenRedgifsInWebViewPatch.kt
@@ -8,146 +8,41 @@
 package app.morphe.patches.reddit.customclients.sync.syncforreddit.fix.redgifswebview
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
-import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.reddit.customclients.AppCompatibility
 import app.morphe.patches.reddit.customclients.ExtensionPatches
-import app.morphe.patcher.util.proxy.mutableTypes.MutableField.Companion.toMutable
 import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstructionOrThrow
-import com.android.tools.smali.dexlib2.AccessFlags
-import com.android.tools.smali.dexlib2.immutable.ImmutableField
-import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
-import org.w3c.dom.Element
 
-private const val SETTINGS_FIELD_NAME = "redgifsWebview"
 private const val HELPER_CLASS = "Lapp/morphe/extension/syncforreddit/RedgifsWebViewHelper;"
-
-// Adds a new boolean field to SettingsSingleton$Settings, the app's settings holder --
-// AND makes it actually load from SharedPreferences. Settings is NOT Gson/reflection
-// backed: SettingsSingleton.p(Context) populates a new Settings instance by calling
-// SharedPreferences.getBoolean(key, default) individually, once per known field. A field
-// that isn't also read there never gets populated -- it silently stays at its Java
-// default (false) forever, regardless of what the user toggles in the UI. (Learned this
-// the hard way: the checkbox worked and toggled fine, but had no runtime effect at all,
-// because this half of the wiring was missing.)
-internal val addRedgifsWebviewSettingField = bytecodePatch {
-    compatibleWith(*AppCompatibility.SyncForReddit)
-
-    execute {
-        classDefForEach { classDef ->
-            if (classDef.sourceFile != "SettingsSingleton.java" || !classDef.type.endsWith("\$Settings;")) {
-                return@classDefForEach
-            }
-
-            mutableClassDefBy(classDef).fields.add(
-                ImmutableField(
-                    classDef.type,
-                    SETTINGS_FIELD_NAME,
-                    "Z",
-                    AccessFlags.PUBLIC.value,
-                    null,
-                    null,
-                    null,
-                ).toMutable()
-            )
-        }
-
-        loadSettingsFingerprint.method.apply {
-            val dohIndex = indexOfFirstInstructionOrThrow {
-                val reference = (this as? ReferenceInstruction)?.reference as? FieldReference
-                reference?.name == "doh"
-            }
-            val settingsClass = (getInstruction<ReferenceInstruction>(dohIndex).reference as FieldReference).definingClass
-            val settingsReg = getInstruction<TwoRegisterInstruction>(dohIndex).registerB
-            // settingsReg is the live Settings instance being built; the SharedPreferences
-            // instance is loaded once at the top of the method and reused for every field's
-            // read via the same register (v0) the "doh" read (and every other field) uses here.
-            addInstructions(
-                dohIndex + 1,
-                """
-                const-string v4, "$SETTINGS_FIELD_NAME"
-                const/4 v5, 0x0
-                invoke-interface { v0, v4, v5 }, Landroid/content/SharedPreferences;->getBoolean(Ljava/lang/String;Z)Z
-                move-result v4
-                iput-boolean v4, v$settingsReg, $settingsClass->$SETTINGS_FIELD_NAME:Z
-                """
-            )
-        }
-    }
-}
-
-// Adds a checkbox preference wired to the new field, in the same "Other" security category
-// as the existing "DNS over HTTPS" checkbox.
-internal val addRedgifsWebviewSettingUi = resourcePatch {
-    compatibleWith(*AppCompatibility.SyncForReddit)
-
-    execute {
-        document("res/xml/cat_security.xml").use { document ->
-            val preference = document.createElement(
-                "com.laurencedawson.reddit_sync.ui.preferences.defaults.SyncCheckBoxPreference"
-            ).apply {
-                setAttribute("android:icon", "@drawable/outline_open_in_browser_24")
-                setAttribute("android:title", "Open Redgifs links in browser view")
-                setAttribute("android:key", SETTINGS_FIELD_NAME)
-                setAttribute(
-                    "android:summary",
-                    "If a Redgifs video fails to load in the native player" +
-                        " (\"Error connecting to Redgifs\"), automatically open it in an" +
-                        " in-app browser view as a fallback instead of showing the error."
-                )
-                setAttribute("android:defaultValue", "false")
-            }
-
-            val dohPreference = document.getElementsByTagName(
-                "com.laurencedawson.reddit_sync.ui.preferences.defaults.SyncCheckBoxPreference"
-            ).let { nodes ->
-                (0 until nodes.length)
-                    .map { nodes.item(it) as Element }
-                    .first { it.getAttribute("android:key") == "doh" }
-            }
-
-            dohPreference.parentNode.insertBefore(preference, dohPreference.nextSibling)
-        }
-    }
-}
 
 @Suppress("unused")
 val openRedgifsInWebView = bytecodePatch(
-    name = "Open Redgifs links in WebView",
-    description = "Adds a setting (Settings > Security > \"Open Redgifs links in browser view\")" +
-        " to fall back to an in-app WebView when Redgifs videos fail to load in the native" +
-        " player (\"Error connecting to Redgifs\"). Off by default. The native/API player is" +
-        " always tried first; the WebView only opens as a fallback on failure. Redgifs pages" +
-        " in the WebView also auto-accept the cookie consent banner and keep it accepted" +
-        " between opens.",
+    name = "Open Redgifs links in WebView on failure",
+    description = "When a Redgifs video fails to load in the native player" +
+        " (\"Error connecting to Redgifs\"), automatically falls back to an in-app WebView" +
+        " instead of showing the error. The native/API player is always tried first; the" +
+        " WebView only opens as a fallback on failure. Redgifs pages in the WebView also" +
+        " try to auto-accept the cookie consent banner and keep it accepted between opens.",
 ) {
     compatibleWith(*AppCompatibility.SyncForReddit)
 
-    dependsOn(addRedgifsWebviewSettingField, addRedgifsWebviewSettingUi, ExtensionPatches.Sync)
+    dependsOn(ExtensionPatches.Sync)
 
     execute {
         // Hook the failure listener of the Redgifs playback flow instead of the link
         // opener: the native/API player always runs first, and only an actual failure
         // (dead endpoint, 404 on a malformed ID, bot detection, ...) opens the WebView.
-        // On fallback we finish the player and skip its error handling entirely:
-        // no error flash before the WebView appears, and Back from the WebView returns
-        // to the page that opened the player instead of a dead error screen.
+        // Unconditional -- no settings gate. On fallback we finish the player and skip
+        // its error handling entirely: no error flash before the WebView appears, and
+        // Back from the WebView returns to the page that opened the player instead of
+        // a dead error screen.
         redgifsErrorListenerFingerprint.method.apply {
             addInstructions(
                 0,
                 """
-                invoke-static { }, Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton;->d()Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton;
-                move-result-object v0
-                invoke-virtual { v0 }, Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton;->j()Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton${'$'}Settings;
-                move-result-object v0
-                iget-boolean v0, v0, Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton${'$'}Settings;->$SETTINGS_FIELD_NAME:Z
-                if-eqz v0, :noFallback
                 iget-object v0, p0, Lcom/laurencedawson/reddit_sync/ui/fragments/ImageViewerFragment${'$'}g0;->b:Lcom/laurencedawson/reddit_sync/ui/fragments/ImageViewerFragment;
                 invoke-virtual { v0 }, Landroidx/fragment/app/Fragment;->B0()Landroidx/fragment/app/FragmentActivity;
                 move-result-object v0

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifswebview/OpenRedgifsInWebViewPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifswebview/OpenRedgifsInWebViewPatch.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 wchill.
+ * https://github.com/wchill/patcheddit
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+
+package app.morphe.patches.reddit.customclients.sync.syncforreddit.fix.redgifswebview
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patches.reddit.customclients.AppCompatibility
+import app.morphe.patcher.util.proxy.mutableTypes.MutableField.Companion.toMutable
+import app.morphe.util.indexOfFirstInstructionOrThrow
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.immutable.ImmutableField
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import org.w3c.dom.Element
+
+private const val SETTINGS_FIELD_NAME = "redgifsWebview"
+
+// Adds a new boolean field to SettingsSingleton$Settings, the app's settings holder --
+// AND makes it actually load from SharedPreferences. Settings is NOT Gson/reflection
+// backed: SettingsSingleton.p(Context) populates a new Settings instance by calling
+// SharedPreferences.getBoolean(key, default) individually, once per known field. A field
+// that isn't also read there never gets populated -- it silently stays at its Java
+// default (false) forever, regardless of what the user toggles in the UI. (Learned this
+// the hard way: the checkbox worked and toggled fine, but had no runtime effect at all,
+// because this half of the wiring was missing.)
+internal val addRedgifsWebviewSettingField = bytecodePatch {
+    compatibleWith(*AppCompatibility.SyncForReddit)
+
+    execute {
+        classDefForEach { classDef ->
+            if (classDef.sourceFile != "SettingsSingleton.java" || !classDef.type.endsWith("\$Settings;")) {
+                return@classDefForEach
+            }
+
+            mutableClassDefBy(classDef).fields.add(
+                ImmutableField(
+                    classDef.type,
+                    SETTINGS_FIELD_NAME,
+                    "Z",
+                    AccessFlags.PUBLIC.value,
+                    null,
+                    null,
+                    null,
+                ).toMutable()
+            )
+        }
+
+        loadSettingsFingerprint.method.apply {
+            val dohIndex = indexOfFirstInstructionOrThrow {
+                val reference = (this as? ReferenceInstruction)?.reference as? FieldReference
+                reference?.name == "doh"
+            }
+            val settingsClass = (getInstruction<ReferenceInstruction>(dohIndex).reference as FieldReference).definingClass
+            val settingsReg = getInstruction<TwoRegisterInstruction>(dohIndex).registerB
+            // settingsReg is the live Settings instance being built; the SharedPreferences
+            // instance is loaded once at the top of the method and reused for every field's
+            // read via the same register (v0) the "doh" read (and every other field) uses here.
+            addInstructions(
+                dohIndex + 1,
+                """
+                const-string v4, "$SETTINGS_FIELD_NAME"
+                const/4 v5, 0x0
+                invoke-interface { v0, v4, v5 }, Landroid/content/SharedPreferences;->getBoolean(Ljava/lang/String;Z)Z
+                move-result v4
+                iput-boolean v4, v$settingsReg, $settingsClass->$SETTINGS_FIELD_NAME:Z
+                """
+            )
+        }
+    }
+}
+
+// Adds a checkbox preference wired to the new field, in the same "Other" security category
+// as the existing "DNS over HTTPS" checkbox.
+internal val addRedgifsWebviewSettingUi = resourcePatch {
+    compatibleWith(*AppCompatibility.SyncForReddit)
+
+    execute {
+        document("res/xml/cat_security.xml").use { document ->
+            val preference = document.createElement(
+                "com.laurencedawson.reddit_sync.ui.preferences.defaults.SyncCheckBoxPreference"
+            ).apply {
+                setAttribute("android:icon", "@drawable/outline_open_in_browser_24")
+                setAttribute("android:title", "Open Redgifs links in browser view")
+                setAttribute("android:key", SETTINGS_FIELD_NAME)
+                setAttribute(
+                    "android:summary",
+                    "If Redgifs videos fail to load (\"Error connecting to Redgifs\"), this opens" +
+                        " them in an in-app browser view instead of the native player, which may" +
+                        " work when the normal method doesn't."
+                )
+                setAttribute("android:defaultValue", "false")
+            }
+
+            val dohPreference = document.getElementsByTagName(
+                "com.laurencedawson.reddit_sync.ui.preferences.defaults.SyncCheckBoxPreference"
+            ).let { nodes ->
+                (0 until nodes.length)
+                    .map { nodes.item(it) as Element }
+                    .first { it.getAttribute("android:key") == "doh" }
+            }
+
+            dohPreference.parentNode.insertBefore(preference, dohPreference.nextSibling)
+        }
+    }
+}
+
+@Suppress("unused")
+val openRedgifsInWebView = bytecodePatch(
+    name = "Open Redgifs links in WebView",
+    description = "Adds a setting (Settings > Security > \"Open Redgifs links in browser view\")" +
+        " to open Redgifs links in an in-app WebView instead of the native player. Off by" +
+        " default; some users have reported Redgifs videos failing to load" +
+        " (\"Error connecting to Redgifs\") in ways this works around.",
+) {
+    compatibleWith(*AppCompatibility.SyncForReddit)
+
+    dependsOn(addRedgifsWebviewSettingField, addRedgifsWebviewSettingUi)
+
+    execute {
+        openRedgifsLinkFingerprint.method.apply {
+            addInstructions(
+                0,
+                """
+                invoke-static { }, Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton;->d()Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton;
+                move-result-object v0
+                invoke-virtual { v0 }, Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton;->j()Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton${'$'}Settings;
+                move-result-object v0
+                iget-boolean v0, v0, Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton${'$'}Settings;->$SETTINGS_FIELD_NAME:Z
+                if-eqz v0, :useNativePlayer
+                invoke-static { p0, p3 }, Lcom/laurencedawson/reddit_sync/ui/activities/WebViewActivity;->K0(Landroid/content/Context;Ljava/lang/String;)Landroid/content/Intent;
+                move-result-object v0
+                invoke-virtual { p0, v0 }, Landroid/content/Context;->startActivity(Landroid/content/Intent;)V
+                return-void
+                :useNativePlayer
+                """
+            )
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifswebview/OpenRedgifsInWebViewPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/sync/syncforreddit/fix/redgifswebview/OpenRedgifsInWebViewPatch.kt
@@ -9,19 +9,24 @@ package app.morphe.patches.reddit.customclients.sync.syncforreddit.fix.redgifswe
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.reddit.customclients.AppCompatibility
+import app.morphe.patches.reddit.customclients.ExtensionPatches
 import app.morphe.patcher.util.proxy.mutableTypes.MutableField.Companion.toMutable
+import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstructionOrThrow
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.immutable.ImmutableField
 import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import org.w3c.dom.Element
 
 private const val SETTINGS_FIELD_NAME = "redgifsWebview"
+private const val HELPER_CLASS = "Lapp/morphe/extension/syncforreddit/RedgifsWebViewHelper;"
 
 // Adds a new boolean field to SettingsSingleton$Settings, the app's settings holder --
 // AND makes it actually load from SharedPreferences. Settings is NOT Gson/reflection
@@ -92,9 +97,9 @@ internal val addRedgifsWebviewSettingUi = resourcePatch {
                 setAttribute("android:key", SETTINGS_FIELD_NAME)
                 setAttribute(
                     "android:summary",
-                    "If Redgifs videos fail to load (\"Error connecting to Redgifs\"), this opens" +
-                        " them in an in-app browser view instead of the native player, which may" +
-                        " work when the normal method doesn't."
+                    "If a Redgifs video fails to load in the native player" +
+                        " (\"Error connecting to Redgifs\"), automatically open it in an" +
+                        " in-app browser view as a fallback instead of showing the error."
                 )
                 setAttribute("android:defaultValue", "false")
             }
@@ -116,16 +121,24 @@ internal val addRedgifsWebviewSettingUi = resourcePatch {
 val openRedgifsInWebView = bytecodePatch(
     name = "Open Redgifs links in WebView",
     description = "Adds a setting (Settings > Security > \"Open Redgifs links in browser view\")" +
-        " to open Redgifs links in an in-app WebView instead of the native player. Off by" +
-        " default; some users have reported Redgifs videos failing to load" +
-        " (\"Error connecting to Redgifs\") in ways this works around.",
+        " to fall back to an in-app WebView when Redgifs videos fail to load in the native" +
+        " player (\"Error connecting to Redgifs\"). Off by default. The native/API player is" +
+        " always tried first; the WebView only opens as a fallback on failure. Redgifs pages" +
+        " in the WebView also auto-accept the cookie consent banner and keep it accepted" +
+        " between opens.",
 ) {
     compatibleWith(*AppCompatibility.SyncForReddit)
 
-    dependsOn(addRedgifsWebviewSettingField, addRedgifsWebviewSettingUi)
+    dependsOn(addRedgifsWebviewSettingField, addRedgifsWebviewSettingUi, ExtensionPatches.Sync)
 
     execute {
-        openRedgifsLinkFingerprint.method.apply {
+        // Hook the failure listener of the Redgifs playback flow instead of the link
+        // opener: the native/API player always runs first, and only an actual failure
+        // (dead endpoint, 404 on a malformed ID, bot detection, ...) opens the WebView.
+        // On fallback we finish the player and skip its error handling entirely:
+        // no error flash before the WebView appears, and Back from the WebView returns
+        // to the page that opened the player instead of a dead error screen.
+        redgifsErrorListenerFingerprint.method.apply {
             addInstructions(
                 0,
                 """
@@ -134,13 +147,53 @@ val openRedgifsInWebView = bytecodePatch(
                 invoke-virtual { v0 }, Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton;->j()Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton${'$'}Settings;
                 move-result-object v0
                 iget-boolean v0, v0, Lcom/laurencedawson/reddit_sync/singleton/SettingsSingleton${'$'}Settings;->$SETTINGS_FIELD_NAME:Z
-                if-eqz v0, :useNativePlayer
-                invoke-static { p0, p3 }, Lcom/laurencedawson/reddit_sync/ui/activities/WebViewActivity;->K0(Landroid/content/Context;Ljava/lang/String;)Landroid/content/Intent;
+                if-eqz v0, :noFallback
+                iget-object v0, p0, Lcom/laurencedawson/reddit_sync/ui/fragments/ImageViewerFragment${'$'}g0;->b:Lcom/laurencedawson/reddit_sync/ui/fragments/ImageViewerFragment;
+                invoke-virtual { v0 }, Landroidx/fragment/app/Fragment;->B0()Landroidx/fragment/app/FragmentActivity;
                 move-result-object v0
-                invoke-virtual { p0, v0 }, Landroid/content/Context;->startActivity(Landroid/content/Intent;)V
+                if-eqz v0, :noFallback
+                iget-object v1, p0, Lcom/laurencedawson/reddit_sync/ui/fragments/ImageViewerFragment${'$'}g0;->a:Ljava/lang/String;
+                invoke-static { v0, v1 }, Lcom/laurencedawson/reddit_sync/ui/activities/WebViewActivity;->K0(Landroid/content/Context;Ljava/lang/String;)Landroid/content/Intent;
+                move-result-object v1
+                invoke-virtual { v0, v1 }, Landroid/content/Context;->startActivity(Landroid/content/Intent;)V
+                invoke-virtual { v0 }, Landroid/app/Activity;->finish()V
                 return-void
-                :useNativePlayer
+                :noFallback
                 """
+            )
+        }
+
+        // Auto-accept the CookieYes consent banner on redgifs pages loaded in the
+        // in-app WebView (all logic lives in the extension helper; no extra
+        // registers needed here since onPageFinished's params are the arguments).
+        webViewClientOnPageFinishedFingerprint.method.apply {
+            addInstructions(
+                0,
+                """
+                invoke-static { p1, p2 }, $HELPER_CLASS->onPageFinished(Landroid/webkit/WebView;Ljava/lang/String;)V
+                """
+            )
+        }
+
+        // Sync wipes all cookies on every fresh WebView open. Replace the wipe
+        // with a helper call that skips it for redgifs URLs, so the consent the
+        // auto-click above accepts actually persists. Single-instruction ops
+        // only -- no control flow inserted into the target method.
+        webViewFragmentOnViewCreatedFingerprint.method.apply {
+            val index = indexOfFirstInstructionOrThrow {
+                val reference = getReference<MethodReference>()
+                reference?.name == "removeAllCookie" &&
+                    reference.definingClass == "Landroid/webkit/CookieManager;"
+            }
+            addInstructions(
+                index,
+                """
+                iget-object v0, p0, Lcom/laurencedawson/reddit_sync/ui/fragments/WebViewFragment;->r0:Ljava/lang/String;
+                """
+            )
+            replaceInstruction(
+                index + 1,
+                "invoke-static { p1, v0 }, $HELPER_CLASS->removeAllCookieUnlessRedgifs(Landroid/webkit/CookieManager;Ljava/lang/String;)V"
             )
         }
     }


### PR DESCRIPTION
## Summary

Sync for Reddit currently fails to open Redgifs links, showing "Error connecting to Redgifs" instead of playing the video.

Root cause: Sync's legacy Redgifs flow is a 3-step Volley request chain — get OAuth token → get client IP via `GET /info` → get gif via `GET /v2/gifs/{id}`. Redgifs has removed `/info` entirely (confirmed 404 as of 2026-08-12); it was only ever used to populate the legacy `user-addr` query parameter. Since step 2 now fails outright, the chain never reaches step 3, so the gif never resolves.

The existing `FixRedgifsApiPatch` already emulates Redgifs' old (also-removed) OAuth endpoint locally rather than hitting the dead network endpoint. This PR extends the same technique to `/info`: emulate a local `{"remote-addr": "..."}` response instead of proxying to the network. Current Redgifs endpoints accept but ignore the `user-addr` value derived from this, confirmed via direct testing against the live API (a placeholder value works fine), and cross-checked against how other actively-maintained Redgifs clients (yt-dlp, Voyager, Hydra, RedditRepostSleuth) handle auth — none of them use `/info` or any IP-lookup step at all.

The fix lives in the shared `BaseFixRedgifsApiPatch`/`RedgifsTokenManager` extension code, so it applies to Sync, Boost for Reddit, and BaconReader simultaneously, not just Sync.

## Test plan

- [x] Built patcheddit from source and applied the patched bundle to `com.laurencedawson.reddit_sync` v23.06.30-13:39 with `morphe-desktop`
- [x] Decompiled the patched APK to confirm the new emulation code is present and correctly wired into the interceptor
- [x] Installed on a physical Pixel 8 Pro and confirmed Redgifs links open and play correctly, where they previously failed
- [x] Verified via direct API testing that the real `/info` endpoint 404s, and that the downstream `/v2/gifs/{id}` fetch succeeds regardless of what `user-addr` value it's given